### PR TITLE
SWS-86 Update standalone tests to work with the Agent as well as the Collector

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,6 @@ pipeline {
         string(name: 'COLLECTOR_QUEUE_SIZE', defaultValue: '3000000')
 
         booleanParam(name: 'DELETE_JAEGER_AT_END', defaultValue: true, description: 'Delete Jaeger instance at end of the test')
-        booleanParam(name: 'DELETE_EXAMPLE_AT_END', defaultValue: true, description: 'Delete the target application at end of the test')
         string(name: 'JAEGER_SAMPLING_RATE', defaultValue: '1.0', description: '0.0 to 1.0 percent of spans to record')
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
         string(name: 'ES_BULK_WORKERS', defaultValue: '10', description: '--es.bulk.workers')
         string(name: 'ES_BULK_FLUSH_INTERVAL', defaultValue: '1s', description: '--es.bulk.flush-interval')
         string(name: 'THREAD_COUNT', defaultValue: '100', description: 'The number of client threads to run')
+        string(name: 'WORKER_PODS', defaultValue: '1', description: 'The number of pods to run client threads in')
         string(name: 'DELAY', defaultValue: '100', description: 'delay in milliseconds between each span creation')
         string(name: 'COLLECTOR_PODS', defaultValue: '1')
         string(name: 'COLLECTOR_QUEUE_SIZE', defaultValue: '3000000')
@@ -115,7 +116,7 @@ pipeline {
                 withEnv(["JAVA_HOME=${ tool 'jdk8' }", "PATH+MAVEN=${tool 'maven-3.5.2'}/bin:${env.JAVA_HOME}/bin"]) {
                     sh 'git status'
                     sh 'mvn -Dtest=false -DfailIfNoTests=false -DskipITs clean install'
-                    sh 'mvn --activate-profiles openshift -Dtest=false -DfailIfNoTests=false clean install fabric8:deploy -Dduration.in.minutes=${DURATION_IN_MINUTES} -Ddelay=${DELAY} -Djaeger.sampling.rate=${JAEGER_SAMPLING_RATE} -Djaeger.agent.host=${JAEGER_AGENT_HOST} -Duser.agent.or.collector=${USE_AGENT_OR_COLLECTOR} -Djaeger.collector.port=${JAEGER_COLLECTOR_PORT} -Djaeger.collector.host=${JAEGER_COLLECTOR_HOST}'
+                    sh 'mvn --activate-profiles openshift -Dtest=false -DfailIfNoTests=false clean install fabric8:deploy -Dpod.count=${WORKER_PODS} -Dduration.in.minutes=${DURATION_IN_MINUTES} -Ddelay=${DELAY} -Djaeger.sampling.rate=${JAEGER_SAMPLING_RATE} -Djaeger.agent.host=${JAEGER_AGENT_HOST} -Duser.agent.or.collector=${USE_AGENT_OR_COLLECTOR} -Djaeger.collector.port=${JAEGER_COLLECTOR_PORT} -Djaeger.collector.host=${JAEGER_COLLECTOR_HOST}'
                     sh 'mvn clean test'
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ pipeline {
     agent any
     options {
         disableConcurrentBuilds()
-        timeout(time: 8, unit: 'HOURS')
+        /*timeout(time: 8, unit: 'HOURS')*/
     }
     environment {
         JAEGER_AGENT_HOST = "localhost"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,19 +22,18 @@ pipeline {
         string(name: 'ES_BULK_WORKERS', defaultValue: '10', description: '--es.bulk.workers')
         string(name: 'ES_BULK_FLUSH_INTERVAL', defaultValue: '1s', description: '--es.bulk.flush-interval')
         string(name: 'THREAD_COUNT', defaultValue: '100', description: 'The number of client threads to run')
-        string(name: 'DELAY', defaultValue: '10', description: 'delay in milliseconds between each span creation')
+        string(name: 'DELAY', defaultValue: '100', description: 'delay in milliseconds between each span creation')
         string(name: 'COLLECTOR_PODS', defaultValue: '1')
         string(name: 'COLLECTOR_QUEUE_SIZE', defaultValue: '3000000')
 
         booleanParam(name: 'DELETE_JAEGER_AT_END', defaultValue: true, description: 'Delete Jaeger instance at end of the test')
         string(name: 'JAEGER_SAMPLING_RATE', defaultValue: '1.0', description: '0.0 to 1.0 percent of spans to record')
     }
-
     stages {
         stage('Set name and description') {
             steps {
                 script {
-                    currentBuild.displayName =params.USE_AGENT_OR_COLLECTOR +" " + params.SPAN_STORAGE_TYPE + " " + params.THREAD_COUNT + " " + params.ITERATIONS + " " + params.JAEGER_SAMPLING_RATE
+                    currentBuild.displayName =params.SPAN_STORAGE_TYPE + " " + params.USE_AGENT_OR_COLLECTOR + " " + params.THREAD_COUNT + " X " + params.DURATION_IN_MINUTES + " min " + params.JAEGER_SAMPLING_RATE
                     currentBuild.description = currentBuild.displayName
                 }
             }
@@ -45,7 +44,13 @@ pipeline {
                 sh 'env | sort'
             }
         }
+        stage('Delete Old Job') {
+            steps {
+                sh 'oc delete job jaeger-standalone-performance-tests || true'
+            }
+        }
         stage('Cleanup, checkout, build') {
+        /* FIXME restore checkout scm */
             steps {
                 deleteDir()
                 checkout scm
@@ -104,19 +109,14 @@ pipeline {
                 openshiftVerifyService apiURL: '', authToken: '', namespace: '', svcName: 'jaeger-collector', verbose: 'false'
             }
         }
+        /* For Agent we need to deploy */
         stage('Run tests'){
             steps{
                 withEnv(["JAVA_HOME=${ tool 'jdk8' }", "PATH+MAVEN=${tool 'maven-3.5.2'}/bin:${env.JAVA_HOME}/bin"]) {
                     sh 'git status'
                     sh 'mvn -Dtest=false -DfailIfNoTests=false -DskipITs clean install'
-                    sh 'mvn exec:java'
-                }
-                script {
-                    env.TRACE_COUNT=readFile 'traceCount.txt'
-                    currentBuild.description = currentBuild.description + " Trace count " + env.TRACE_COUNT
-                }
-                withEnv(["JAVA_HOME=${ tool 'jdk8' }", "PATH+MAVEN=${tool 'maven-3.5.2'}/bin:${env.JAVA_HOME}/bin"]) {
-                    sh 'mvn clean -DexpectedTraceCount=${TRACE_COUNT} test'
+                    sh 'mvn --activate-profiles openshift -Dtest=false -DfailIfNoTests=false clean install fabric8:deploy -Dduration.in.minutes=${DURATION_IN_MINUTES} -Ddelay=${DELAY} -Djaeger.sampling.rate=${JAEGER_SAMPLING_RATE} -Djaeger.agent.host=${JAEGER_AGENT_HOST} -Duser.agent.or.collector=${USE_AGENT_OR_COLLECTOR} -Djaeger.collector.port=${JAEGER_COLLECTOR_PORT} -Djaeger.collector.host=${JAEGER_COLLECTOR_HOST}'
+                    sh 'mvn clean test'
                 }
 
             }
@@ -129,6 +129,11 @@ pipeline {
                 script {
                     sh 'oc delete all,template,daemonset,configmap -l jaeger-infra'
                 }
+            }
+        }
+        stage('Delete Job at end') {
+            steps {
+                sh 'oc delete job jaeger-standalone-performance-tests || true'
             }
         }
         stage('Cleanup pods') {

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Start by downloading and building Jaeger based on the instructions under **Runni
 + Clone this repo (`git@github.com:Hawkular-QE/SimpleJaegerExample.git`) and cd into it.
 + Optional: `export USE_AGENT_OR_COLLECTOR=agent` if you want to test using the agent
 + Optional: `export CASSANDRA_CLUSTER_IP=localhost` or wherever cassandra is running, default is cassandra
++ Optional: `export RUNNING_IN_OPENSHIFT=false` if not on OpenShift
 + `mvn exec:java`
 + `mvn clean -DexpectedTraceCount=nnnnnn test`  where nnnnnn is the trace count output by the previous step
 
@@ -91,6 +92,7 @@ Note that the `-es.` arguments are optional but may be needed for long running t
 ### Checkout and run the tests
 + Clone this repo (`git@github.com:Hawkular-QE/SimpleJaegerExample.git`) and cd into it.
 + Optional: `export USE_AGENT_OR_COLLECTOR=agent` if you want to test using the agent
++ Optional: `export RUNNING_IN_OPENSHIFT=false` if not on OpenShift
 + `export SPAN_STORAGE_TYPE=elasticsearch`
 + `export ELASTICSEARCH_HOST=localhost` or wherever elasticsearch is running, default is elasticsearch
 + `mvn exec:java`

--- a/pom.xml
+++ b/pom.xml
@@ -14,17 +14,23 @@
         <checkstyle.version>8.8</checkstyle.version>
         <elasticsearch.version>5.6.6</elasticsearch.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
+        <fabric8.kubernetes.client.version>3.1.8</fabric8.kubernetes.client.version>
+        <fabric8.kubernetes.model.version>2.0.8</fabric8.kubernetes.model.version>
         <fabric8-maven-plugin.version>3.5.35</fabric8-maven-plugin.version>
+        <fabric8.openshift.client.version>3.1.8</fabric8.openshift.client.version>
         <glassfish.jersey.client.version>2.26</glassfish.jersey.client.version>
         <jackson.version>2.9.4</jackson.version>
         <jaeger.version>0.24.0</jaeger.version>
         <javax.ws.rs.version>2.1</javax.ws.rs.version>
         <junit.version>4.12</junit.version>
+        <log4j.version>1.2.17</log4j.version>
         <maven.checkstyle.plugin.version>2.17</maven.checkstyle.plugin.version>
         <maven.compiler.plugin.version>3.7.0</maven.compiler.plugin.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.versions.plugin.version>2.5</maven.versions.plugin.version>
+        <okhttp3.version>3.9.0</okhttp3.version>
+        <slf4j.version>1.7.25</slf4j.version>
 
         <!-- Default parameter values for deploying to OpenShift -->
         <delay>10</delay>
@@ -62,17 +68,37 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.25</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <version>1.2.17</version>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>openshift-client</artifactId>
+            <version>${fabric8.openshift.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-client</artifactId>
+            <version>${fabric8.kubernetes.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-model</artifactId>
+            <version>${fabric8.kubernetes.model.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp3.version}</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,13 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <enricher>
+                                <config>
+                                    <fmp-controller>
+                                        <type>Job</type>
+                                    </fmp-controller>
+                                </config>
+                            </enricher>
                             <resources>
                                 <env>
                                     <DELAY>${delay}</DELAY>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <checkstyle.version>8.8</checkstyle.version>
         <elasticsearch.version>5.6.6</elasticsearch.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-        <fabric8-maven-plugin.version>3.5.33</fabric8-maven-plugin.version>
+        <fabric8-maven-plugin.version>3.5.35</fabric8-maven-plugin.version>
         <glassfish.jersey.client.version>2.26</glassfish.jersey.client.version>
         <jackson.version>2.9.4</jackson.version>
         <jaeger.version>0.24.0</jaeger.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <version>1.1</version>
 
     <properties>
+        <!-- Dependency versions -->
         <cassandra.driver.core.version>3.4.0</cassandra.driver.core.version>
         <checkstyle.version>8.8</checkstyle.version>
         <elasticsearch.version>5.6.6</elasticsearch.version>
@@ -24,6 +25,22 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.versions.plugin.version>2.5</maven.versions.plugin.version>
+
+        <!-- Default parameter values for deploying to OpenShift -->
+        <delay>10</delay>
+        <duration.in.minutes>1</duration.in.minutes>
+        <jaeger.agent.host>localhost</jaeger.agent.host>
+        <jaeger.collector.host>jaeger-collector</jaeger.collector.host>
+        <jaeger.collector.port>14268</jaeger.collector.port>
+        <jaeger.flush.interval>100</jaeger.flush.interval>
+        <jaeger.max.packet.size>0</jaeger.max.packet.size>
+        <jaeger.max.queue.size>100000</jaeger.max.queue.size>
+        <jaeger.sampling.rate>1.0</jaeger.sampling.rate>
+        <jaeger.udp.port>6831</jaeger.udp.port>
+        <test.service.name>standalong</test.service.name>
+        <thread.count>100</thread.count>
+        <use.agent.or.collector>COLLECTOR</use.agent.or.collector>
+        <use.logging.reporter>false</use.logging.reporter>
     </properties>
 
     <dependencies>
@@ -147,6 +164,49 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>openshift</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>io.fabric8</groupId>
+                        <artifactId>fabric8-maven-plugin</artifactId>
+                        <version>${fabric8-maven-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>resource</goal>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <resources>
+                                <env>
+                                    <DELAY>${delay}</DELAY>
+                                    <DURATION_IN_MINUTES>${duration.in.minutes}</DURATION_IN_MINUTES>
+                                    <JAEGER_AGENT_HOST>${jaeger.agent.host}</JAEGER_AGENT_HOST>
+                                    <JAEGER_COLLECTOR_HOST>${jaeger.collector.host}</JAEGER_COLLECTOR_HOST>
+                                    <JAEGER_COLLECTOR_PORT>${jaeger.collector.port}</JAEGER_COLLECTOR_PORT>
+                                    <JAEGER_FLUSH_INTERVAL>${jaeger.flush.interval}</JAEGER_FLUSH_INTERVAL>
+                                    <JAEGER_MAX_PACKET_SIZE>${jaeger.max.packet.size}</JAEGER_MAX_PACKET_SIZE>
+                                    <JAEGER_MAX_QUEUE_SIZE>${jaeger.max.queue.size}</JAEGER_MAX_QUEUE_SIZE>
+                                    <JAEGER_SAMPLING_RATE>${jaeger.sampling.rate}</JAEGER_SAMPLING_RATE>
+                                    <JAEGER_UDP_PORT>${jaeger.udp.port}</JAEGER_UDP_PORT>
+                                    <TEST_SERVICE_NAME>${test.service.name}</TEST_SERVICE_NAME>
+                                    <THREAD_COUNT>${thread.count}</THREAD_COUNT>
+                                    <USE_AGENT_OR_COLLECTOR>${use.agent.or.collector}</USE_AGENT_OR_COLLECTOR>
+                                    <USE_LOGGING_REPORTER>${use.logging.reporter}</USE_LOGGING_REPORTER>
+                                </env>
+                            </resources>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <reporting>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <jaeger.max.queue.size>100000</jaeger.max.queue.size>
         <jaeger.sampling.rate>1.0</jaeger.sampling.rate>
         <jaeger.udp.port>6831</jaeger.udp.port>
+        <pod.count>1</pod.count>
         <test.service.name>standalong</test.service.name>
         <thread.count>100</thread.count>
         <use.agent.or.collector>COLLECTOR</use.agent.or.collector>

--- a/src/main/fabric8/job.yml
+++ b/src/main/fabric8/job.yml
@@ -3,7 +3,7 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: jaeger-standalone-performance-test
+      - name: jaeger-standalone-performance-tests
       - name: jaeger-agent
         image: jaegertracing/jaeger-agent
         ports:
@@ -16,4 +16,4 @@ spec:
           protocol: UDP
         command:
         - "/go/bin/agent-linux"
-        - "--collector.host-port=jaeger-collector.jaeger-infra.svc:14267"
+        - "--collector.host-port=jaeger-collector:14267"

--- a/src/main/fabric8/job.yml
+++ b/src/main/fabric8/job.yml
@@ -1,9 +1,11 @@
 spec:
+  parallelism: ${pod.count}
+  completions: ${pod.count}
   template:
     spec:
       restartPolicy: Never
       containers:
-      - name: jaeger-standalone-performance-tests
+      - name: ${project.artifactId}
       - name: jaeger-agent
         image: jaegertracing/jaeger-agent
         ports:

--- a/src/main/fabric8/job.yml
+++ b/src/main/fabric8/job.yml
@@ -1,6 +1,7 @@
 spec:
   template:
     spec:
+      restartPolicy: Never
       containers:
       - name: jaeger-standalone-performance-test
       - name: jaeger-agent

--- a/src/main/java/io/jaegertracing/qe/CreateTraces.java
+++ b/src/main/java/io/jaegertracing/qe/CreateTraces.java
@@ -52,6 +52,8 @@ public class CreateTraces {
     private static final String USE_AGENT_OR_COLLECTOR = envs.getOrDefault("USE_AGENT_OR_COLLECTOR", "COLLECTOR");
     private static final String USE_LOGGING_REPORTER = envs.getOrDefault("USE_LOGGING_REPORTER", "false");
 
+    public static final String TRACES_CREATED_MESSAGE = "TRACES_CREATED: ";
+
     private static final Logger logger = LoggerFactory.getLogger(CreateTraces.class);
     private static Tracer tracer;
 
@@ -126,15 +128,13 @@ public class CreateTraces {
             logger.info("Got " + numberFormat.format(traceCount) + " traces");
             tracesCreated += traceCount;
         }
-        logger.info("Got a total of " + numberFormat.format(tracesCreated) + " traces");
+        logger.info(TRACES_CREATED_MESSAGE + tracesCreated);
         Files.write(Paths.get("traceCount.txt"), Long.toString(tracesCreated).getBytes(), StandardOpenOption.CREATE);
 
         final Instant createEndTime = Instant.now();
         long duration = Duration.between(createStartTime, createEndTime).toMillis();
         logger.info("Finished all " + THREAD_COUNT + " threads; Created " + numberFormat.format(tracesCreated) + " traces" + " in " + duration + " milliseconds");
-
-        System.setProperty("EATME", "" + tracesCreated);
-
+        
         closeTracer();
     }
 

--- a/src/test/java/io/jaegertracing/qe/tests/ValidateTracesTest.java
+++ b/src/test/java/io/jaegertracing/qe/tests/ValidateTracesTest.java
@@ -1,6 +1,9 @@
 package io.jaegertracing.qe.tests;
 
+import static io.jaegertracing.qe.CreateTraces.TRACES_CREATED_MESSAGE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.ResultSet;
@@ -9,8 +12,10 @@ import com.datastax.driver.core.Session;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.opentracing.Span;
-import io.opentracing.Tracer;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.jaegertracing.qe.tests.util.PodWatcher;
 
 import java.io.IOException;
 import java.text.NumberFormat;
@@ -18,9 +23,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -36,9 +41,10 @@ import org.slf4j.LoggerFactory;
 public class ValidateTracesTest {
     private static final Map<String, String> envs = System.getenv();
 
+    public static final String APPLICATION_NAME = envs.getOrDefault("APPLICATION_NAME", "jaeger-standalone-performance-tests");
     private static final String CASSANDRA_CLUSTER_IP = envs.getOrDefault("CASSANDRA_CLUSTER_IP", "cassandra");
     private static final String CASSANDRA_KEYSPACE_NAME = envs.getOrDefault("CASSANDRA_KEYSPACE_NAME", "jaeger_v1_test");
-    private static final Integer DELAY = new Integer(envs.getOrDefault("DELAY", "1"));
+    private static final Integer DURATION_IN_MINUTES = new Integer(envs.getOrDefault("DURATION_IN_MINUTES", "5"));
     private static final String ELASTICSEARCH_HOST = envs.getOrDefault("ELASTICSEARCH_HOST", "elasticsearch");
     private static final Integer ELASTICSEARCH_PORT = new Integer(envs.getOrDefault("ELASTICSEARCH_PORT", "9200"));
     private static final String SPAN_STORAGE_TYPE = envs.getOrDefault("SPAN_STORAGE_TYPE", "cassandra");
@@ -48,7 +54,33 @@ public class ValidateTracesTest {
 
     @Test
     public void countTraces() throws Exception {
-        int expectedTraceCount = Integer.valueOf(System.getProperty("expectedTraceCount"));
+        // TODO 1. Refactor; 2. Can I add a route to elasticsearch or cassandra so this will work outside of OpenShift?
+        Thread.sleep(30 * 1000);  // Give all pods time to start up
+
+        OpenShiftClient client = new DefaultOpenShiftClient();
+        List<Pod> pods = client.pods()
+                .inNamespace(client.getNamespace())
+                .withLabel("app=" + APPLICATION_NAME)
+                .list()
+                .getItems();
+
+        assertNotNull("Expected at least one pod", pods);
+        assertTrue("Expected at least one pod", pods.size() > 0);
+
+        logger.info("Waiting for " + pods.size() + " pod(s) to finish");
+        CountDownLatch podsCountDownLatch = new CountDownLatch(pods.size());
+        client.pods()
+                .inNamespace(client.getNamespace())
+                .withLabel("app=" + APPLICATION_NAME)
+                .watch(new PodWatcher(podsCountDownLatch));
+        podsCountDownLatch.await(DURATION_IN_MINUTES + 1, TimeUnit.MINUTES);      // set timeout to DURATION + 1?
+
+        Integer expectedTraceCount = 0;
+        for (Pod pod : pods) {
+            String targetPodName = pod.getMetadata().getName();
+            Integer traceCount = getTraceCountForPod(client, targetPodName);
+            expectedTraceCount += traceCount;
+        }
         logger.info("EXPECTED_TRACE_COUNT " + numberFormat.format(expectedTraceCount));
 
         Instant startTime = Instant.now();
@@ -64,7 +96,31 @@ public class ValidateTracesTest {
         Instant countEndTime = Instant.now();
         long countDuration = Duration.between(startTime, countEndTime).toMillis();
         logger.info("Counting " + numberFormat.format(actualTraceCount) + " traces took " + countDuration / 1000 + "." + countDuration % 1000 + " seconds.");
-        assertEquals("Did not find expected number of traces", expectedTraceCount, actualTraceCount);
+        assertEquals("Did not find expected number of traces", expectedTraceCount.intValue(), actualTraceCount);
+    }
+
+
+    /**
+     *
+     *
+     * @param client An OpenShiftClient
+     * @param podName Name of the pod whose log we want to search
+     * @return number of traces created in this pod
+     */
+    private Integer getTraceCountForPod(OpenShiftClient client, String podName) {
+        String log  = client.pods()
+                .inNamespace(client.getNamespace())
+                .withName(podName)
+                .inContainer(APPLICATION_NAME)
+                .tailingLines(3)
+                .getLog();
+
+        int startOfCount = log.indexOf(TRACES_CREATED_MESSAGE) + TRACES_CREATED_MESSAGE.length();
+        int endOfCount = log.indexOf("\n", startOfCount);
+        String countString = log.substring(startOfCount, endOfCount);
+        Integer tracesWrittenCount = Integer.valueOf(countString);
+
+        return tracesWrittenCount;
     }
 
 
@@ -183,40 +239,6 @@ public class ValidateTracesTest {
         int totalTraceCount = consumer.getRowCount();
 
         return totalTraceCount;
-    }
-
-    class WriteTraces implements Callable<Integer> {
-        Tracer tracer;
-        int id;
-        int durationInMinutes;
-
-        public WriteTraces(Tracer tracer, int durationInMinutes, int id) {
-            this.tracer = tracer;
-            this.durationInMinutes = durationInMinutes;
-            this.id = id;
-        }
-
-        @Override
-        public Integer call() throws Exception {
-            int  spanCount = 0;
-            String s = "Thread " + id;
-            logger.debug("Starting " + s);
-
-            Instant finish = Instant.now().plus(durationInMinutes, ChronoUnit.MINUTES);
-            while (Instant.now().isBefore(finish)) {
-                Span span = tracer.buildSpan(s).start();
-                try {
-                    span.setTag("iteration", spanCount);
-                    spanCount++;
-                    Thread.sleep(DELAY);
-                } catch (InterruptedException e) {
-                    logger.warn("Got interrupted exception", 3);
-                }
-                span.finish();
-            }
-
-            return spanCount;
-        }
     }
 
 

--- a/src/test/java/io/jaegertracing/qe/tests/util/PodWatcher.java
+++ b/src/test/java/io/jaegertracing/qe/tests/util/PodWatcher.java
@@ -1,0 +1,41 @@
+package io.jaegertracing.qe.tests.util;
+
+import static io.jaegertracing.qe.tests.ValidateTracesTest.APPLICATION_NAME;
+
+import io.fabric8.kubernetes.api.model.ContainerStatus;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watcher;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PodWatcher implements Watcher<Pod> {
+    private static final Logger logger = LoggerFactory.getLogger(PodWatcher.class.getName());
+    CountDownLatch countDownLatch;
+
+    public PodWatcher(CountDownLatch latch) {
+        logger.debug("PodWatcher created");
+        this.countDownLatch = latch;
+    }
+
+    @Override
+    public void eventReceived(Action action, Pod pod) {
+        logger.debug("Got action " + action.name() + " for pod " + pod.getMetadata().getName());  // TODO logger.debug
+        List<ContainerStatus> statuses = pod.getStatus().getContainerStatuses();
+        for (ContainerStatus status : statuses) {
+            if (status.getName().equals(APPLICATION_NAME) && status.getState().getTerminated() != null) {
+                logger.info(pod.getMetadata().getName() + " has been TERMINATED!!!!");
+                countDownLatch.countDown();
+            }
+        }
+    }
+
+    @Override
+    public void onClose(KubernetesClientException e) {
+        logger.info("onClose called");
+    }
+}


### PR DESCRIPTION
Updating the tests to work with an Agent requires

-- Running the tests as part of an OpenShift job rather than as a simple unit test
-- Getting the trace count from each pod before verifying the result via ElasticSearch or Cassandra.

I've also update the job so that it can run multiple test worker pods if desired.
